### PR TITLE
Browse API: Fix taxType -> string

### DIFF
--- a/src/Browse/Types/Taxes.php
+++ b/src/Browse/Types/Taxes.php
@@ -49,7 +49,7 @@ class Taxes extends \DTS\eBaySDK\Types\BaseType
             'elementName' => 'taxPercentage'
         ],
         'taxType' => [
-            'type' => 'DTS\eBaySDK\Browse\Types\TaxType',
+            'type' => 'string',
             'repeatable' => false,
             'attribute' => false,
             'elementName' => 'taxType'


### PR DESCRIPTION
JsonParser::assignProperties error when getting item using Browse Service. Fixed with:
change string 52
from 'type' => 'DTS\eBaySDK\Browse\Types\TaxType',
to 'type' => 'string',

Fix confirm in https://github.com/davidtsadler/ebay-sdk-php/issues/150 from davidtsadler